### PR TITLE
Fixed server start/restart issues

### DIFF
--- a/resources/clj/new/dv.fulcro_template/src/main/app/server/server.clj
+++ b/resources/clj/new/dv.fulcro_template/src/main/app/server/server.clj
@@ -44,10 +44,10 @@
                    (catch Exception e
                      (println "EXCeption 2" e " type: " (type e))))]
         (log/info "started server val: " r)
-        (when-not r
-          (when (< 10000 port))
-          (recur
-            (merge (service/make-service-map)
-              (update pedestal-config ::http/port inc)))))))
+        (or r
+            (when (< 10000 port)
+              (recur
+                (merge (service/make-service-map)
+                       (update pedestal-config ::http/port inc))))))))
   :stop
   (http/stop http-server))


### PR DESCRIPTION
 - Server variable `r` needs to be returned to mount for it to be able to restart it, otherwise :stop will fail
 - Fixed empty `(when (< 10000 port))` form, added the `(recur ...)` inside it